### PR TITLE
Makes the path truly optional in LibPixel::Client#url

### DIFF
--- a/lib/libpixel/client.rb
+++ b/lib/libpixel/client.rb
@@ -28,7 +28,15 @@ module LibPixel
       uri.to_s
     end
 
-    def url(path, options={})
+    def url(path_or_options, options={})
+      path = nil
+
+      if path_or_options.respond_to? :fetch
+        options = path_or_options
+      else
+        path = path_or_options
+      end
+
       path = "/" if path.nil? || path.empty?
       query = options.map { |k,v| "#{k}=#{URI.encode_www_form_component(v)}" }.join("&")
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -68,6 +68,12 @@ describe LibPixel::Client do
       assert_equal url, client.url("", src: "url")
       assert_equal url, client.url(nil, src: "url")
     end
+
+    it "sets the path to '/' if the path is omitted" do
+      client = LibPixel::Client.new(host: "test.libpx.com")
+      url = "http://test.libpx.com/?src=url"
+      assert_equal url, client.url(src: "url")
+    end
   end
 
 end


### PR DESCRIPTION
Seems to work.
